### PR TITLE
add task to add user to libvirt group

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -15,3 +15,14 @@
   register: result
   until: result is success
   retries: 3
+
+- name: ensure libvirt group exists
+  group:
+    name: libvirt
+    state: present
+
+- name: add '{{ ansible_user }}' to libvirt group
+  user:
+    name: "{{ ansible_user }}"
+    groups: libvirt
+    append: yes


### PR DESCRIPTION
Current playbook fails at defining networks due to the "ansible_user" not in the "libvirt" group.

"msg": "authentication unavailable: no polkit agent available to authenticate action 'org.libvirt.unix.manage'"